### PR TITLE
Fixed stop.mdx

### DIFF
--- a/docs/api/setup-worker/stop.mdx
+++ b/docs/api/setup-worker/stop.mdx
@@ -18,7 +18,7 @@ worker.start()
 
 // Write the stop method on the window
 // to access during runtime.
-window.__mswStop = worker.stop
+window.__mswStop = () => worker.stop()
 ```
 
 Calling `window.__mswStop()` in the browser would disable the mocking for the current page.


### PR DESCRIPTION
function reference can't be used here as `stop` relies on `this` context which isn't the expected worker when calling it on window.